### PR TITLE
make navigation-panel scrollable

### DIFF
--- a/standalone.css
+++ b/standalone.css
@@ -12,7 +12,7 @@
 	.navigation-panel {
 		max-height: calc(100vw - 160.59px);
 		overflow-y: auto;
-		overflow-x: hidden;
+		overflow-x: auto;
 		scroll-snap-type: y mandatory;
 	}
 	.navigation-panel::-webkit-scrollbar {


### PR DESCRIPTION
这样就能通过拖动来显示右侧overflow的按钮（喜欢、书签等）